### PR TITLE
Update lighttpd.conf

### DIFF
--- a/addon_files/redmatic/etc/lighttpd.conf
+++ b/addon_files/redmatic/etc/lighttpd.conf
@@ -5,3 +5,8 @@ $HTTP["url"] =~ "^/(addons/red/).*" {
   proxy.header = ( "upgrade" => "enable")
   server.errorfile-prefix  = "/usr/local/addons/redmatic/www/lighttpd-error-"
 }
+
+# Proxy rule to redirect request to amazon-echo-hub node from node-red-contrib-amazon-echo
+$HTTP["url"] =~ "(^/description.xml)|(^/api/.*/lights)" {
+proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 6502)))
+}


### PR DESCRIPTION
Add proxy rule for Alexa Integration

Proxy rule to redirect request to amazon-echo-hub node from node-red-contrib-amazon-echo.
Documentation needs to be added pointing the user to use port 6502 for amazon-echo-hub node.
This will work only if the listening port for the hub node can be configured.